### PR TITLE
Typo fix in documentation

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -210,8 +210,8 @@ Traditional PGP key servers allow everyone to get a list of all the users who
 are interested in secure email. This seems unnecessary and invites abuse. To
 prevent this, we make sure that you can only look up a user’s information if
 you already know their email address. User’s locations in the Merkle Tree will
-be calculated with an Verifiable Random Function 
-`(VRF) = H(Sig(k, user_id))`. This forces attackers to perform an online query
+be calculated with a Verifiable Random Function (VRF), conceptually equal to
+`H(Sig(k, user_id))`. This forces attackers to perform an online query
 to the server to learn a user’s location in the tree. The deterministic
 signature proves that there is only one correct location in the tree for the
 user. 


### PR DESCRIPTION
Changing `an` to `a` seems correct, but I took a guess at what the next bit should have been.