### PR TITLE
docs: Fix link to protobuf definitions

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -116,7 +116,7 @@ recipient has installed.
 
 ## API Reference 
 
-*   [Proto Definitions](impl/proto/keytransparency_v1_service/keytransparency_v1_service.proto)
+*   [Proto Definitions](../impl/proto/keytransparency_v1_service/keytransparency_v1_service.proto)
 *   [HTTP API](http_apis.md)
 
 ## Multiple Apps and Keys 


### PR DESCRIPTION
design.md is located a level below project root, so the link needs to start with `../impl` instead of `impl`.