### PR TITLE
Fix protobuf link in design.md.

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -116,7 +116,7 @@ recipient has installed.
 
 ## API Reference 
 
-*   [Proto Definitions](impl/proto/keytransparency_v1_service/keytransparency_v1_service.proto)
+*   [Proto Definitions](../impl/proto/keytransparency_v1_service/keytransparency_v1_service.proto)
 *   [HTTP API](http_apis.md)
 
 ## Multiple Apps and Keys 


### PR DESCRIPTION
Currently 404. This PR fixes the link in design.md to the protocol buffers spec for the service.