### PR TITLE
regenerate generated files with protoc 3.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
   - go get -u github.com/fzipp/gocyclo
   - go get -u github.com/gordonklaus/ineffassign
   - go get -u github.com/client9/misspell/cmd/misspell
-  - go get -u github.com/google/key-transparency/cmd/...
+  - go get -u ./cmd/...
   - govendor sync
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
   - go get -u github.com/fzipp/gocyclo
   - go get -u github.com/gordonklaus/ineffassign
   - go get -u github.com/client9/misspell/cmd/misspell
+  - go get -u github.com/google/key-transparency/cmd/...
   - govendor sync
 
 script:

--- a/core/proto/ctmap/ctmap.pb.go
+++ b/core/proto/ctmap/ctmap.pb.go
@@ -111,6 +111,27 @@ func (m *MapHead) String() string            { return proto.CompactTextString(m)
 func (*MapHead) ProtoMessage()               {}
 func (*MapHead) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *MapHead) GetRealm() string {
+	if m != nil {
+		return m.Realm
+	}
+	return ""
+}
+
+func (m *MapHead) GetEpoch() int64 {
+	if m != nil {
+		return m.Epoch
+	}
+	return 0
+}
+
+func (m *MapHead) GetRoot() []byte {
+	if m != nil {
+		return m.Root
+	}
+	return nil
+}
+
 func (m *MapHead) GetIssueTime() *google_protobuf.Timestamp {
 	if m != nil {
 		return m.IssueTime
@@ -162,6 +183,27 @@ func (m *DigitallySigned) String() string            { return proto.CompactTextS
 func (*DigitallySigned) ProtoMessage()               {}
 func (*DigitallySigned) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{2} }
 
+func (m *DigitallySigned) GetHashAlgorithm() DigitallySigned_HashAlgorithm {
+	if m != nil {
+		return m.HashAlgorithm
+	}
+	return DigitallySigned_NONE
+}
+
+func (m *DigitallySigned) GetSigAlgorithm() DigitallySigned_SignatureAlgorithm {
+	if m != nil {
+		return m.SigAlgorithm
+	}
+	return DigitallySigned_ANONYMOUS
+}
+
+func (m *DigitallySigned) GetSignature() []byte {
+	if m != nil {
+		return m.Signature
+	}
+	return nil
+}
+
 // GetLeafRequest for a verifiable map leaf.
 type GetLeafRequest struct {
 	// index includes the requested leaf index.
@@ -174,6 +216,20 @@ func (m *GetLeafRequest) Reset()                    { *m = GetLeafRequest{} }
 func (m *GetLeafRequest) String() string            { return proto.CompactTextString(m) }
 func (*GetLeafRequest) ProtoMessage()               {}
 func (*GetLeafRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
+
+func (m *GetLeafRequest) GetIndex() []byte {
+	if m != nil {
+		return m.Index
+	}
+	return nil
+}
+
+func (m *GetLeafRequest) GetEpoch() uint64 {
+	if m != nil {
+		return m.Epoch
+	}
+	return 0
+}
 
 // GetLeafResponse for a verifiable map leaf.
 type GetLeafResponse struct {
@@ -189,6 +245,20 @@ func (m *GetLeafResponse) String() string            { return proto.CompactTextS
 func (*GetLeafResponse) ProtoMessage()               {}
 func (*GetLeafResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{4} }
 
+func (m *GetLeafResponse) GetLeafData() []byte {
+	if m != nil {
+		return m.LeafData
+	}
+	return nil
+}
+
+func (m *GetLeafResponse) GetNeighbors() [][]byte {
+	if m != nil {
+		return m.Neighbors
+	}
+	return nil
+}
+
 // UpdateLeafRequest submits a change for the value at index.
 type UpdateLeafRequest struct {
 	// index includes the updated leaf index.
@@ -201,6 +271,20 @@ func (m *UpdateLeafRequest) Reset()                    { *m = UpdateLeafRequest{
 func (m *UpdateLeafRequest) String() string            { return proto.CompactTextString(m) }
 func (*UpdateLeafRequest) ProtoMessage()               {}
 func (*UpdateLeafRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{5} }
+
+func (m *UpdateLeafRequest) GetIndex() []byte {
+	if m != nil {
+		return m.Index
+	}
+	return nil
+}
+
+func (m *UpdateLeafRequest) GetMutation() []byte {
+	if m != nil {
+		return m.Mutation
+	}
+	return nil
+}
 
 // UpdateLeafResponse returns the current value of index.
 type UpdateLeafResponse struct {

--- a/core/proto/keymaster/keymaster.pb.go
+++ b/core/proto/keymaster/keymaster.pb.go
@@ -93,11 +93,25 @@ func (m *Metadata) String() string            { return proto.CompactTextString(m
 func (*Metadata) ProtoMessage()               {}
 func (*Metadata) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *Metadata) GetKeyId() string {
+	if m != nil {
+		return m.KeyId
+	}
+	return ""
+}
+
 func (m *Metadata) GetAddedAt() *google_protobuf.Timestamp {
 	if m != nil {
 		return m.AddedAt
 	}
 	return nil
+}
+
+func (m *Metadata) GetDescription() string {
+	if m != nil {
+		return m.Description
+	}
+	return ""
 }
 
 // SigningKey represents a private key.
@@ -122,6 +136,20 @@ func (m *SigningKey) GetMetadata() *Metadata {
 	return nil
 }
 
+func (m *SigningKey) GetKeyMaterial() []byte {
+	if m != nil {
+		return m.KeyMaterial
+	}
+	return nil
+}
+
+func (m *SigningKey) GetStatus() SigningKey_KeyStatus {
+	if m != nil {
+		return m.Status
+	}
+	return SigningKey_ACTIVE
+}
+
 // VerifyingKey represents a public key.
 type VerifyingKey struct {
 	// metadata contains information about this key..
@@ -142,6 +170,20 @@ func (m *VerifyingKey) GetMetadata() *Metadata {
 		return m.Metadata
 	}
 	return nil
+}
+
+func (m *VerifyingKey) GetKeyMaterial() []byte {
+	if m != nil {
+		return m.KeyMaterial
+	}
+	return nil
+}
+
+func (m *VerifyingKey) GetStatus() VerifyingKey_KeyStatus {
+	if m != nil {
+		return m.Status
+	}
+	return VerifyingKey_ACTIVE
 }
 
 // KeySet contains a set of public and private keys.

--- a/core/proto/keytransparency_v1_types/keytransparency_v1_types.pb.go
+++ b/core/proto/keytransparency_v1_types/keytransparency_v1_types.pb.go
@@ -61,6 +61,20 @@ func (m *Committed) String() string            { return proto.CompactTextString(
 func (*Committed) ProtoMessage()               {}
 func (*Committed) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{0} }
 
+func (m *Committed) GetKey() []byte {
+	if m != nil {
+		return m.Key
+	}
+	return nil
+}
+
+func (m *Committed) GetData() []byte {
+	if m != nil {
+		return m.Data
+	}
+	return nil
+}
+
 // Profile contains data hidden behind the cryptographic commitment.
 type Profile struct {
 	// Keys is a map of application IDs to keys.
@@ -119,6 +133,13 @@ func (m *Entry) Reset()                    { *m = Entry{} }
 func (m *Entry) String() string            { return proto.CompactTextString(m) }
 func (*Entry) ProtoMessage()               {}
 func (*Entry) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{3} }
+
+func (m *Entry) GetCommitment() []byte {
+	if m != nil {
+		return m.Commitment
+	}
+	return nil
+}
 
 func (m *Entry) GetAuthorizedKeys() []*PublicKey {
 	if m != nil {
@@ -283,6 +304,20 @@ func (m *KeyValue) String() string            { return proto.CompactTextString(m
 func (*KeyValue) ProtoMessage()               {}
 func (*KeyValue) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{5} }
 
+func (m *KeyValue) GetKey() []byte {
+	if m != nil {
+		return m.Key
+	}
+	return nil
+}
+
+func (m *KeyValue) GetValue() []byte {
+	if m != nil {
+		return m.Value
+	}
+	return nil
+}
+
 // SignedKV is a signed change to a map entry.
 type SignedKV struct {
 	// key_value is a serialized KeyValue.
@@ -316,6 +351,13 @@ func (m *SignedKV) GetSignatures() map[string]*ctmap.DigitallySigned {
 	return nil
 }
 
+func (m *SignedKV) GetPrevious() []byte {
+	if m != nil {
+		return m.Previous
+	}
+	return nil
+}
+
 // GetEntryRequest for a user object.
 type GetEntryRequest struct {
 	// user_id is the user identifier. Most commonly an email address.
@@ -326,6 +368,13 @@ func (m *GetEntryRequest) Reset()                    { *m = GetEntryRequest{} }
 func (m *GetEntryRequest) String() string            { return proto.CompactTextString(m) }
 func (*GetEntryRequest) ProtoMessage()               {}
 func (*GetEntryRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{7} }
+
+func (m *GetEntryRequest) GetUserId() string {
+	if m != nil {
+		return m.UserId
+	}
+	return ""
+}
 
 // GetEntryResponse returns a requested user entry.
 type GetEntryResponse struct {
@@ -353,6 +402,20 @@ func (m *GetEntryResponse) String() string            { return proto.CompactText
 func (*GetEntryResponse) ProtoMessage()               {}
 func (*GetEntryResponse) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{8} }
 
+func (m *GetEntryResponse) GetVrf() []byte {
+	if m != nil {
+		return m.Vrf
+	}
+	return nil
+}
+
+func (m *GetEntryResponse) GetVrfProof() []byte {
+	if m != nil {
+		return m.VrfProof
+	}
+	return nil
+}
+
 func (m *GetEntryResponse) GetCommitted() *Committed {
 	if m != nil {
 		return m.Committed
@@ -374,6 +437,13 @@ func (m *GetEntryResponse) GetSmh() *ctmap.SignedMapHead {
 	return nil
 }
 
+func (m *GetEntryResponse) GetSmhSct() []byte {
+	if m != nil {
+		return m.SmhSct
+	}
+	return nil
+}
+
 // ListEntryHistoryRequest gets a list of historical keys for a user.
 type ListEntryHistoryRequest struct {
 	// user_id is the user identifier.
@@ -388,6 +458,27 @@ func (m *ListEntryHistoryRequest) Reset()                    { *m = ListEntryHis
 func (m *ListEntryHistoryRequest) String() string            { return proto.CompactTextString(m) }
 func (*ListEntryHistoryRequest) ProtoMessage()               {}
 func (*ListEntryHistoryRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{9} }
+
+func (m *ListEntryHistoryRequest) GetUserId() string {
+	if m != nil {
+		return m.UserId
+	}
+	return ""
+}
+
+func (m *ListEntryHistoryRequest) GetStart() int64 {
+	if m != nil {
+		return m.Start
+	}
+	return 0
+}
+
+func (m *ListEntryHistoryRequest) GetPageSize() int32 {
+	if m != nil {
+		return m.PageSize
+	}
+	return 0
+}
 
 // ListEntryHistoryResponse requests a paginated history of keys for a user.
 type ListEntryHistoryResponse struct {
@@ -410,6 +501,13 @@ func (m *ListEntryHistoryResponse) GetValues() []*GetEntryResponse {
 	return nil
 }
 
+func (m *ListEntryHistoryResponse) GetNextStart() int64 {
+	if m != nil {
+		return m.NextStart
+	}
+	return 0
+}
+
 // UpdateEntryRequest updates a user's profile.
 type UpdateEntryRequest struct {
 	// user_id specifies the id for the user who's profile is being updated.
@@ -422,6 +520,13 @@ func (m *UpdateEntryRequest) Reset()                    { *m = UpdateEntryReques
 func (m *UpdateEntryRequest) String() string            { return proto.CompactTextString(m) }
 func (*UpdateEntryRequest) ProtoMessage()               {}
 func (*UpdateEntryRequest) Descriptor() ([]byte, []int) { return fileDescriptor0, []int{11} }
+
+func (m *UpdateEntryRequest) GetUserId() string {
+	if m != nil {
+		return m.UserId
+	}
+	return ""
+}
 
 func (m *UpdateEntryRequest) GetEntryUpdate() *EntryUpdate {
 	if m != nil {

--- a/impl/proto/keytransparency_v1_service/keytransparency_v1_service.pb.go
+++ b/impl/proto/keytransparency_v1_service/keytransparency_v1_service.pb.go
@@ -46,7 +46,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for KeyTransparencyService service
 
@@ -197,7 +197,7 @@ var _KeyTransparencyService_serviceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: fileDescriptor0,
+	Metadata: "keytransparency_v1_service.proto",
 }
 
 func init() { proto.RegisterFile("keytransparency_v1_service.proto", fileDescriptor0) }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -175,10 +175,10 @@
 			"versionExact": "v3.1.0-rc.0"
 		},
 		{
-			"checksumSHA1": "b0AQfM6Lh6+IHEAGvrwuU7k9iok=",
+			"checksumSHA1": "7DR73QX622RtgwohJc2DzBe+gmQ=",
 			"path": "github.com/coreos/etcd/etcdserver/etcdserverpb",
-			"revision": "83347907774bf36cbb261c594a32fd7b0f5dd9f6",
-			"revisionTime": "2016-10-14T21:40:17Z",
+			"revision": "017ea3df50e9b379d5ba3bff647cce6dd8c01a0d",
+			"revisionTime": "2017-01-15T21:12:01Z",
 			"version": "v3.1.0-rc.0",
 			"versionExact": "v3.1.0-rc.0"
 		},

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1212,5 +1212,5 @@
 			"revisionTime": "2016-09-28T15:37:09Z"
 		}
 	],
-	"rootPath": "github.com/gdbelvin/key-transparency"
+	"rootPath": "github.com/google/key-transparency"
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -593,10 +593,16 @@
 			"revisionTime": "2016-10-12T20:53:35Z"
 		},
 		{
-			"checksumSHA1": "SVXOQdpDBh0ihdZ5aIflgdA+Rpw=",
+			"checksumSHA1": "kBeNcaKk56FguvPSUCEaH6AxpRc=",
 			"path": "github.com/golang/protobuf/proto",
-			"revision": "98fa357170587e470c5f27d3c3ea0947b71eb455",
-			"revisionTime": "2016-10-12T20:53:35Z"
+			"revision": "8ee79997227bf9b34611aee7946ae64735e6fd93",
+			"revisionTime": "2016-11-17T03:31:26Z"
+		},
+		{
+			"checksumSHA1": "ZIqcmeEc/EU9HsKJHuJ1Iy+ZNgE=",
+			"path": "github.com/golang/protobuf/protoc-gen-go",
+			"revision": "8ee79997227bf9b34611aee7946ae64735e6fd93",
+			"revisionTime": "2016-11-17T03:31:26Z"
 		},
 		{
 			"checksumSHA1": "juNiTc9bfhQYo4BkWc83sW4Z5gw=",
@@ -1134,64 +1140,70 @@
 			"revisionTime": "2016-10-09T23:30:37Z"
 		},
 		{
-			"checksumSHA1": "r2jmzn/o6RN6PT9FRRtBeAfgNEk=",
+			"checksumSHA1": "epHwh7hDQSYzDowPIbw8vnLzPS0=",
 			"path": "google.golang.org/grpc",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
 			"checksumSHA1": "08icuA15HRkdYCt6H+Cs90RPQsY=",
 			"path": "google.golang.org/grpc/codes",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
-			"checksumSHA1": "Vd1MU+Ojs7GeS6jE52vlxtXvIrI=",
+			"checksumSHA1": "AGkvu7gY1jWK7v5s9a8qLlH2gcQ=",
 			"path": "google.golang.org/grpc/credentials",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
-			"checksumSHA1": "5R1jXc9mAXky9tPEuWMikTrwCgE=",
+			"checksumSHA1": "bg3wIPzajKt3QZfTG70EPaxDtpk=",
 			"path": "google.golang.org/grpc/credentials/oauth",
-			"revision": "2b7e876a2eb64e93cb8140f497d3ea9d8882279c",
-			"revisionTime": "2016-10-21T00:52:52Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
 			"checksumSHA1": "3Lt5hNAG8qJAYSsNghR5uA1zQns=",
 			"path": "google.golang.org/grpc/grpclog",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
 			"checksumSHA1": "T3Q0p8kzvXFnRkMaK/G8mCv6mc0=",
 			"path": "google.golang.org/grpc/internal",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
-		},
-		{
-			"checksumSHA1": "P64GkSdsTZ8Nxop5HYqZJ6e+iHs=",
-			"path": "google.golang.org/grpc/metadata",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
 			"checksumSHA1": "4GSUFhOQ0kdFlBH4D5OTeKy78z0=",
 			"path": "google.golang.org/grpc/naming",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
 			"checksumSHA1": "3RRoLeH6X2//7tVClOVzxW2bY+E=",
 			"path": "google.golang.org/grpc/peer",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
-			"checksumSHA1": "HQJrtiTtr5eiRsXQLut2R1Q9kuY=",
+			"checksumSHA1": "wzkOAxlah+y75EpH0QVgzb8hdfc=",
+			"path": "google.golang.org/grpc/stats",
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
+		},
+		{
+			"checksumSHA1": "N0TftT6/CyWqp6VRi2DqDx60+Fo=",
+			"path": "google.golang.org/grpc/tap",
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
+		},
+		{
+			"checksumSHA1": "yHpUeGwKoqqwd3cbEp3lkcnvft0=",
 			"path": "google.golang.org/grpc/transport",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
 			"checksumSHA1": "12GqsW8PiRPnezDDy0v4brZrndM=",
@@ -1200,5 +1212,5 @@
 			"revisionTime": "2016-09-28T15:37:09Z"
 		}
 	],
-	"rootPath": "github.com/google/key-transparency"
+	"rootPath": "github.com/gdbelvin/key-transparency"
 }


### PR DESCRIPTION
go get -u google/key-transparency results in a build break. 
go-grpc upgraded to grpc.SupportPackageIsVersion4 
This PR updates the generated files to match.  