### PR TITLE
regenerate generated files with protoc 3.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
   - go get -u github.com/fzipp/gocyclo
   - go get -u github.com/gordonklaus/ineffassign
   - go get -u github.com/client9/misspell/cmd/misspell
+  - go get -u github.com/google/key-transparency/cmd/...
   - govendor sync
 
 script:

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -175,10 +175,10 @@
 			"versionExact": "v3.1.0-rc.0"
 		},
 		{
-			"checksumSHA1": "b0AQfM6Lh6+IHEAGvrwuU7k9iok=",
+			"checksumSHA1": "7DR73QX622RtgwohJc2DzBe+gmQ=",
 			"path": "github.com/coreos/etcd/etcdserver/etcdserverpb",
-			"revision": "83347907774bf36cbb261c594a32fd7b0f5dd9f6",
-			"revisionTime": "2016-10-14T21:40:17Z",
+			"revision": "017ea3df50e9b379d5ba3bff647cce6dd8c01a0d",
+			"revisionTime": "2017-01-15T21:12:01Z",
 			"version": "v3.1.0-rc.0",
 			"versionExact": "v3.1.0-rc.0"
 		},

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -593,10 +593,16 @@
 			"revisionTime": "2016-10-12T20:53:35Z"
 		},
 		{
-			"checksumSHA1": "SVXOQdpDBh0ihdZ5aIflgdA+Rpw=",
+			"checksumSHA1": "kBeNcaKk56FguvPSUCEaH6AxpRc=",
 			"path": "github.com/golang/protobuf/proto",
-			"revision": "98fa357170587e470c5f27d3c3ea0947b71eb455",
-			"revisionTime": "2016-10-12T20:53:35Z"
+			"revision": "8ee79997227bf9b34611aee7946ae64735e6fd93",
+			"revisionTime": "2016-11-17T03:31:26Z"
+		},
+		{
+			"checksumSHA1": "ZIqcmeEc/EU9HsKJHuJ1Iy+ZNgE=",
+			"path": "github.com/golang/protobuf/protoc-gen-go",
+			"revision": "8ee79997227bf9b34611aee7946ae64735e6fd93",
+			"revisionTime": "2016-11-17T03:31:26Z"
 		},
 		{
 			"checksumSHA1": "juNiTc9bfhQYo4BkWc83sW4Z5gw=",
@@ -1134,64 +1140,70 @@
 			"revisionTime": "2016-10-09T23:30:37Z"
 		},
 		{
-			"checksumSHA1": "r2jmzn/o6RN6PT9FRRtBeAfgNEk=",
+			"checksumSHA1": "epHwh7hDQSYzDowPIbw8vnLzPS0=",
 			"path": "google.golang.org/grpc",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
 			"checksumSHA1": "08icuA15HRkdYCt6H+Cs90RPQsY=",
 			"path": "google.golang.org/grpc/codes",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
-			"checksumSHA1": "Vd1MU+Ojs7GeS6jE52vlxtXvIrI=",
+			"checksumSHA1": "AGkvu7gY1jWK7v5s9a8qLlH2gcQ=",
 			"path": "google.golang.org/grpc/credentials",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
-			"checksumSHA1": "5R1jXc9mAXky9tPEuWMikTrwCgE=",
+			"checksumSHA1": "bg3wIPzajKt3QZfTG70EPaxDtpk=",
 			"path": "google.golang.org/grpc/credentials/oauth",
-			"revision": "2b7e876a2eb64e93cb8140f497d3ea9d8882279c",
-			"revisionTime": "2016-10-21T00:52:52Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
 			"checksumSHA1": "3Lt5hNAG8qJAYSsNghR5uA1zQns=",
 			"path": "google.golang.org/grpc/grpclog",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
 			"checksumSHA1": "T3Q0p8kzvXFnRkMaK/G8mCv6mc0=",
 			"path": "google.golang.org/grpc/internal",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
-		},
-		{
-			"checksumSHA1": "P64GkSdsTZ8Nxop5HYqZJ6e+iHs=",
-			"path": "google.golang.org/grpc/metadata",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
 			"checksumSHA1": "4GSUFhOQ0kdFlBH4D5OTeKy78z0=",
 			"path": "google.golang.org/grpc/naming",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
 			"checksumSHA1": "3RRoLeH6X2//7tVClOVzxW2bY+E=",
 			"path": "google.golang.org/grpc/peer",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
-			"checksumSHA1": "HQJrtiTtr5eiRsXQLut2R1Q9kuY=",
+			"checksumSHA1": "wzkOAxlah+y75EpH0QVgzb8hdfc=",
+			"path": "google.golang.org/grpc/stats",
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
+		},
+		{
+			"checksumSHA1": "N0TftT6/CyWqp6VRi2DqDx60+Fo=",
+			"path": "google.golang.org/grpc/tap",
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
+		},
+		{
+			"checksumSHA1": "yHpUeGwKoqqwd3cbEp3lkcnvft0=",
 			"path": "google.golang.org/grpc/transport",
-			"revision": "396f8ba2a6b9039070f4ff97561f5e408828fccd",
-			"revisionTime": "2016-10-26T23:20:24Z"
+			"revision": "50955793b0183f9de69bd78e2ec251cf20aab121",
+			"revisionTime": "2017-01-11T19:10:52Z"
 		},
 		{
 			"checksumSHA1": "12GqsW8PiRPnezDDy0v4brZrndM=",
@@ -1200,5 +1212,5 @@
 			"revisionTime": "2016-09-28T15:37:09Z"
 		}
 	],
-	"rootPath": "github.com/google/key-transparency"
+	"rootPath": "github.com/gdbelvin/key-transparency"
 }


### PR DESCRIPTION
go get -u google/key-transparency results in a build break.
go-grpc upgraded to grpc.SupportPackageIsVersion4
This PR updates the generated files to match.